### PR TITLE
Fix MCP pyproject metadata

### DIFF
--- a/recursive-agents-mcp/pyproject.toml
+++ b/recursive-agents-mcp/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [
-    {name = "Your Name", email = "your.email@example.com"},
+    {name = "Henry Besser", email = "henry.operator.research@gmail.com"},
 ]
 dependencies = [
     "mcp>=0.1.0",


### PR DESCRIPTION
## Summary
- use the real maintainer in `recursive-agents-mcp/pyproject.toml`