### PR TITLE
Remove unused asyncio import

### DIFF
--- a/recursive-agents-mcp/core/data_tools.py
+++ b/recursive-agents-mcp/core/data_tools.py
@@ -11,7 +11,6 @@ queries, and other data sources.
 
 import logging
 from typing import List, Dict, Any, Optional
-import asyncio
 import json
 import httpx
 from urllib.parse import quote


### PR DESCRIPTION
## Summary
- tidy up `data_tools.py` by removing a stray `asyncio` import